### PR TITLE
Control .sh files line endings with .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
Bash scripts are run in Unix environments, so they shouldn't contain Windows style line endings. Moreover to run them seamlessly using Windows Subsystem for Linux (WSL) .sh files can't contain Windows style line endings.

- [X] Bug fix (non-breaking change which fixes an issue)

Remember to refresh the .sh files after the .gitattributes file appears in your local repository. Removing the files and `git checkout .` does the job.