### PR TITLE
Dashboard Top metrics

### DIFF
--- a/src/BurnForMoney.Functions.InternalApi/Configuration/ApplicationConfiguration.cs
+++ b/src/BurnForMoney.Functions.InternalApi/Configuration/ApplicationConfiguration.cs
@@ -23,7 +23,9 @@ namespace BurnForMoney.Functions.InternalApi.Configuration
                     ConnectionStrings = new ConnectionStringsSection
                     {
                         SqlDbConnectionString = config["ConnectionStrings:Sql"]
-                    }
+                    },
+                    PointsThreshold = int.Parse(config["PointsThreshold"]),
+                    Payment = decimal.Parse(config["Payment"])
                 };
 
                 if (!_settings.IsValid())

--- a/src/BurnForMoney.Functions.InternalApi/Configuration/ConfigurationRoot.cs
+++ b/src/BurnForMoney.Functions.InternalApi/Configuration/ConfigurationRoot.cs
@@ -3,6 +3,8 @@ namespace BurnForMoney.Functions.InternalApi.Configuration
     public class ConfigurationRoot
     {
         public ConnectionStringsSection ConnectionStrings { get; set; }
+        public int PointsThreshold { get; set; }
+        public decimal Payment { get; set; }
 
         public bool IsValid()
         {

--- a/src/BurnForMoney.Functions.InternalApi/Functions/Dashboard/DashboardFunc.cs
+++ b/src/BurnForMoney.Functions.InternalApi/Functions/Dashboard/DashboardFunc.cs
@@ -29,8 +29,10 @@ namespace BurnForMoney.Functions.InternalApi.Functions.Dashboard
                 year = int.Parse(yearParameter);
             }
 
+            decimal payment = configuration.Payment;
+            int pointsThreshold = configuration.PointsThreshold;
             var repository = new DashboardReadRepository(configuration.ConnectionStrings.SqlDbConnectionString);
-            var dashboardTop = await repository.GetDashboardTopAsync(month, year);
+            var dashboardTop = await repository.GetDashboardTopAsync(pointsThreshold, payment, month, year);
        
             return new OkObjectResult(dashboardTop);
         }

--- a/src/BurnForMoney.Functions.InternalApi/rest.http
+++ b/src/BurnForMoney.Functions.InternalApi/rest.http
@@ -81,3 +81,6 @@ GET {{baseUrl}}/ranking?take=5&month=2&year=2019
 
 ### Get dashboard header, month 2, year 2019
 GET {{baseUrl}}/dashboardtop?month=2&year=2019
+
+### Get dashboard header (totals)
+GET {{baseUrl}}/dashboardtop

--- a/src/BurnForMoney.Infrastructure/Persistence/Repositories/Dto/DashboardTop.cs
+++ b/src/BurnForMoney.Infrastructure/Persistence/Repositories/Dto/DashboardTop.cs
@@ -1,11 +1,13 @@
-using System;
-
 namespace BurnForMoney.Infrastructure.Persistence.Repositories.Dto
 {
     public class DashboardTop
     {
-        public double Distance { get; set; }
-        public double Time { get; set; }
-        public int Points { get; set; }
+        public double TotalDistance { get; set; }
+        public double TotalTime { get; set; }
+        public int TotalPoints { get; set; }
+        public decimal TotalMoney { get; set; }
+        public int CurrentPoints { get; set; }
+        public int PointsThreshold { get; set; }
+        public decimal Payment { get; set; }
     }
 }


### PR DESCRIPTION
# Description

Reimplemented endpoint for fetching info displayed on dashboard header. Info can now be fetched in two ways:
* **{base_uri}/dashboardtop?month=x&year=y**   -- get info for given month & year
* **{base_uri}/dashboardtop**  -- get accumulated info (concerning all monthly results in DB)

The points threshold for getting bonus money (and the amount of it) configuration settings are stored in Key-Vault and need to be manually updated.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Fetched data with multiple query params through BFM App.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
